### PR TITLE
Fix server-side-rendering by not relying on existence of window

### DIFF
--- a/src/FacebookButton.jsx
+++ b/src/FacebookButton.jsx
@@ -52,7 +52,7 @@ FacebookButton.propTypes = {
 };
 
 FacebookButton.defaultProps = {
-  url: window.url,
+  url: (typeof window !== 'undefined' ? window.url : ''),
   layout: '',
   action: '',
   showFaces: false,

--- a/src/GREEButton.jsx
+++ b/src/GREEButton.jsx
@@ -22,6 +22,6 @@ GREEButton.propTypes = {
 };
 
 GREEButton.defaultProps = {
-  url: window.url,
+  url: (typeof window !== 'undefined' ? window.url : ''),
   type: 0
 };

--- a/src/HatenabookmarkButton.jsx
+++ b/src/HatenabookmarkButton.jsx
@@ -52,7 +52,7 @@ HatenabookmarkButton.propTypes = {
 };
 
 HatenabookmarkButton.defaultProps = {
-  url: window.url,
+  url: (typeof window !== 'undefined' ? window.url : ''),
   layout: '',
   title: ''
 };

--- a/src/LinkedinButton.jsx
+++ b/src/LinkedinButton.jsx
@@ -96,7 +96,7 @@ LinkedinButton.propTypes = {
 };
 
 LinkedinButton.defaultProps = {
-  url: window.url,
+  url: (typeof window !== 'undefined' ? window.url : ''),
   counter: '',
   lang: 'ja'
 };

--- a/src/TwitterTweetButton.jsx
+++ b/src/TwitterTweetButton.jsx
@@ -54,7 +54,7 @@ TwitterTweetButton.propTypes = {
 };
 
 TwitterTweetButton.defaultProps = {
-  url: window.url,
+  url: (typeof window !== 'undefined' ? window.url : ''),
   text: '',
   hashtags: '',
   user: ''


### PR DESCRIPTION
Server-side-rendering is not possible because defaultProps have been initialized with window.url which does not exist on server-side. Setting it to empty value for server-side seems better idea.