### PR TITLE
linkedin button fix (+typo in readme)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Do you want any other social share buttons? Feel free to contanct with me or cre
 - [LINE Button](https://github.com/uraway/react-social-sharebuttons/blob/master/documents/react-line-button.md)
 - [LINE Button 日本語ドキュメント/website](http://uraway.hatenablog.com/entry/2016/02/04/000000)
 
-- [Linkedin Button](https://github.com/uraway/react-social-sharebuttons/blob/master/documents/react-linkedin-button.md)
+- [Linkedin Button](https://github.com/uraway/react-social-sharebuttons/blob/master/documents/react-Linkedin-button.md)
 - [Linkedin Button 日本語ドキュメント/website](http://uraway.hatenablog.com/entry/2016/02/08/000000)
 
 - [TumblrFollow Button](https://github.com/uraway/react-social-sharebuttons/blob/master/documents/react-tumblrfollow-button.md)

--- a/src/LinkedinButton.jsx
+++ b/src/LinkedinButton.jsx
@@ -12,6 +12,7 @@ export default class LinkedinButton extends Component {
       return;
     }
 
+    if (window.IN) delete window.IN;
     const linkedinbutton = this.node;
     const linkedinscript = document.createElement('script');
     linkedinscript.src = '//platform.linkedin.com/in.js';


### PR DESCRIPTION
Fixes a link to the Linkedin Button documentation.

Deletes the global IN variable so subsequent buttons load correctly. Otherwise, the scripts gives a an error like:

"duplicate in.js loaded. ignoring ..."